### PR TITLE
Enabling STS AWS Service

### DIFF
--- a/nebula-dsl/src/main/kotlin/com/orbitalhq/nebula/s3/S3Executor.kt
+++ b/nebula-dsl/src/main/kotlin/com/orbitalhq/nebula/s3/S3Executor.kt
@@ -42,7 +42,7 @@ class S3Executor(private val config: S3Config) : InfrastructureComponent<Localst
 
     override fun start():ComponentInfo<LocalstackContainerConfig> {
         localstack = LocalStackContainer(DockerImageName.parse(config.imageName))
-            .withServices(LocalStackContainer.Service.S3)
+            .withServices(LocalStackContainer.Service.S3, LocalStackContainer.Service.STS)
 
         eventSource.startContainerAndEmitEvents(localstack)
 


### PR DESCRIPTION
When S3 services is enabled in localstack it also needs STS so that Orbital can communicate with the service