### PR TITLE
Dont duplicate the stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Nebula is a Kotlin-based DSL for quickly defining and orchestrating test ecosystems using Docker containers. It allows developers to spin up complex infrastructure stacks (Kafka, databases, HTTP servers, etc.) with associated behaviors for testing and demonstrations.
+
+## Development Commands
+
+### Build and Test
+```bash
+# Build all modules
+mvn clean compile
+
+# Run tests
+mvn test
+
+# Package the application
+mvn package
+
+# Run a specific test class
+mvn test -Dtest=ClassName
+
+# Run tests for a specific module
+mvn test -pl nebula-dsl
+```
+
+### Documentation
+```bash
+# In docs/ directory
+npm run dev    # Start development server
+npm run build  # Build documentation
+npm start      # Start production server
+```
+
+### Release Management
+```bash
+./tag-release.sh  # Automated release tagging and version management
+```
+
+## Architecture
+
+### Multi-Module Structure
+- **nebula-api**: Core API definitions and events
+- **nebula-dsl**: Main DSL implementation and infrastructure components 
+- **nebula-cli**: Command-line interface using PicoCLI
+- **nebula-runtime**: Script execution engine and HTTP server
+
+### Key Technologies
+- **Kotlin 2.2.0** on JVM 21
+- **TestContainers 1.19.0** for container orchestration
+- **Ktor 2.3.12** for HTTP servers and clients
+- **Kotest 5.9.1** for testing with descriptive specifications
+- **Project Reactor** for reactive programming
+
+### Infrastructure Components
+The DSL supports: Kafka, HTTP servers, SQL databases (PostgreSQL/MySQL with JOOQ), MongoDB, S3 (via LocalStack), Hazelcast, Avro/Protobuf schemas.
+
+## Code Patterns
+
+### DSL Scripts
+- Files use `.nebula.kts` extension
+- Kotlin scripting with fluent builder APIs
+- Default imports provide common utilities
+- Components implement `InfrastructureComponent<*>` interface
+
+### Testing
+- Uses Kotest framework with descriptive specifications
+- TestContainers for integration testing
+- Tests located in `src/test/kotlin` directories
+
+### Lifecycle Management
+- Event-driven architecture with lifecycle events
+- Centralized stack runner for orchestration
+- Graceful shutdown handling for containers
+
+## Running Nebula
+
+### CLI Usage
+```bash
+# Execute a script
+nebula script.nebula.kts
+
+# Start HTTP server mode
+nebula --http=8099
+```
+
+### Docker Usage
+```bash
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+  --privileged --network host \
+  orbitalhq/nebula:latest
+```
+
+## Development Notes
+
+- Source code in `src/main/kotlin`, tests in `src/test/kotlin`
+- Maven manages multi-module dependencies
+- Custom S3-based Maven repository at repo.orbitalhq.com
+- Multi-platform Docker builds (AMD64/ARM64)
+- Requires Docker daemon access for TestContainers
+- Uses official Kotlin coding style conventions

--- a/nebula-cli/src/main/kotlin/com/orbitalhq/nebula/cli/NebulaCli.kt
+++ b/nebula-cli/src/main/kotlin/com/orbitalhq/nebula/cli/NebulaCli.kt
@@ -1,6 +1,7 @@
 package com.orbitalhq.nebula.cli
 
 import com.orbitalhq.nebula.NebulaConfig
+import com.orbitalhq.nebula.NebulaStackWithSource
 import com.orbitalhq.nebula.StackRunner
 import com.orbitalhq.nebula.runtime.NebulaScriptExecutor
 import com.orbitalhq.nebula.runtime.server.NebulaServer
@@ -86,9 +87,10 @@ class Nebula : Callable<Int> {
 
         val scriptRunner = NebulaScriptExecutor()
         val stack = scriptRunner.runScript(file)
+        val stackWithSource = NebulaStackWithSource(stack, file.readText())
 
         val stackRunner = StackRunner(nebulaConfig)
-        stackRunner.submit(stack)
+        stackRunner.submit(stackWithSource)
         Runtime.getRuntime().addShutdownHook(Thread {
             if (verbose) spec.commandLine().out.println("Shutting down services...")
             stackRunner.shutDownAll()

--- a/nebula-dsl/src/main/kotlin/com/orbitalhq/nebula/NebulaStack.kt
+++ b/nebula-dsl/src/main/kotlin/com/orbitalhq/nebula/NebulaStack.kt
@@ -16,6 +16,17 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 typealias StackName = String
 
+data class NebulaStackWithSource(
+    val stack: NebulaStack,
+    val source: String
+) {
+    fun withName(id: String):NebulaStackWithSource {
+        return this.copy(stack = stack.withName(id))
+    }
+
+    val name = stack.name
+}
+
 class NebulaStack(
     val name: StackName = NameGenerator.generateName(),
     initialComponents: List<InfrastructureComponent<*>> = emptyList()

--- a/nebula-dsl/src/main/kotlin/com/orbitalhq/nebula/StackRunner.kt
+++ b/nebula-dsl/src/main/kotlin/com/orbitalhq/nebula/StackRunner.kt
@@ -106,7 +106,7 @@ fun NebulaStackWithSource.start(): StackRunner {
  */
 fun NebulaStack.start(): StackRunner {
     val executor = StackRunner()
-    val stackWithSource = NebulaStackWithSource(this, "Source not provided - Random UUID follows - ${UUID.randomUUID().toString()}" )
+    val stackWithSource = NebulaStackWithSource(this, "Source not provided - Random UUID follows - ${UUID.randomUUID()}" )
     executor.submit(stackWithSource)
     return executor
 }

--- a/nebula-runtime/src/main/kotlin/com/orbitalhq/nebula/runtime/NebulaScriptExecutor.kt
+++ b/nebula-runtime/src/main/kotlin/com/orbitalhq/nebula/runtime/NebulaScriptExecutor.kt
@@ -2,6 +2,7 @@ package com.orbitalhq.nebula.runtime
 
 import com.orbitalhq.nebula.NebulaScript
 import com.orbitalhq.nebula.NebulaStack
+import com.orbitalhq.nebula.NebulaStackWithSource
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 import kotlin.script.experimental.api.EvaluationResult
@@ -50,8 +51,14 @@ class NebulaScriptExecutor {
         resultWithDiagnostics.reports.filter { it.severity == ScriptDiagnostic.Severity.ERROR }.forEach { logger.error { it.toString() } }
     }
 
+    @Deprecated("call toStackWithSource")
     fun toStack(string: String): NebulaStack {
         val source = string.toScriptSource()
         return runScript(source)
+    }
+    fun toStackWithSource(string: String): NebulaStackWithSource {
+        val source = string.toScriptSource()
+        val stack = runScript(source)
+        return NebulaStackWithSource(stack, string)
     }
 }


### PR DESCRIPTION
When running in a cluster, we see the stack get duplicated when receiving multiple submissions.

This attempts to address this, by only updating the stack if the submitted stack is different